### PR TITLE
Alert green color added

### DIFF
--- a/Sources/DesignResourcesKit/Color.swift
+++ b/Sources/DesignResourcesKit/Color.swift
@@ -32,6 +32,7 @@ public enum DesignSystemColor: String {
     case lines
     case accent
     case icons
+    case alertGreen
 }
 
 public extension Color {

--- a/Sources/DesignResourcesKit/Colors.xcassets/alertGreen.colorset/Contents.json
+++ b/Sources/DesignResourcesKit/Colors.xcassets/alertGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xC0",
+          "red" : "0x21"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Stakeholders:
@THISISDINOSAUR @tomasstrba 

**Description**:

New alertGreen colour added to our design system, the colour was already used ([see here](https://github.com/duckduckgo/iOS/tree/main/DuckDuckGo/Settings.xcassets/Colors)) but was not added to the design system

**Why are you changing this repo?**

Colour needed in https://app.asana.com/0/1205842942115003/1207746442205594/f

**Checklist**

* [x] Are you changing/adding/removing colors or type styles?
* [x] If yes to the above, are the changes you're making part of the design system?
* [ ] If no to the previous question, have you challenged it and attempted to either change the designs or have the new thing incorporated into the design system?
⚠️ If no to the above question you probably shouldn't open this PR and should consult with the relevant DRIs.


---
###### Internal references:
[DesignResourcesKit documentation](https://app.asana.com/0/1202500774821704/1204423793264693/f) 
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) 
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
