### PR TITLE
Add secondary icon color and secondary fill button style colors

### DIFF
--- a/Sources/DesignResourcesKit/Color.swift
+++ b/Sources/DesignResourcesKit/Color.swift
@@ -32,8 +32,11 @@ public enum DesignSystemColor: String {
     case lines
     case accent
     case icons
+    case iconsSecondary
     case alertGreen
     case alertYellow
+    case buttonsSecondaryFillDefault
+    case buttonsSecondaryFillPressed
 }
 
 public extension Color {

--- a/Sources/DesignResourcesKit/Colors.xcassets/buttonsSecondaryFillDefault.colorset/Contents.json
+++ b/Sources/DesignResourcesKit/Colors.xcassets/buttonsSecondaryFillDefault.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.060",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.180",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/DesignResourcesKit/Colors.xcassets/buttonsSecondaryFillPressed.colorset/Contents.json
+++ b/Sources/DesignResourcesKit/Colors.xcassets/buttonsSecondaryFillPressed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.180",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/DesignResourcesKit/Colors.xcassets/iconsSecondary.colorset/Contents.json
+++ b/Sources/DesignResourcesKit/Colors.xcassets/iconsSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.600",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
**Description**:

Adds colors frequently used in Figma:
* Icons/Secondary
* Button/Secondary Fill/Default
* Button/Secondary Fill/Pressed

**Why are you changing this repo?**

Required for https://app.asana.com/0/72649045549333/1207062886935119/f. 
Design: [Figma](https://www.figma.com/design/N2GbF5HEvopp5iwmAlMwyD/New-Tab-Page-Customization?node-id=611-147699&m=dev)

**Checklist**

* [x] Are you changing/adding/removing colors or type styles?
* [x] If yes to the above, are the changes you're making part of the design system?
* [ ] If no to the previous question, have you challenged it and attempted to either change the designs or have the new thing incorporated into the design system?
⚠️ If no to the above question you probably shouldn't open this PR and should consult with the relevant DRIs.


---
###### Internal references:
[DesignResourcesKit documentation](https://app.asana.com/0/1202500774821704/1204423793264693/f) 
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) 
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
**When ready for review, remember to post the PR in MM**
